### PR TITLE
Message update

### DIFF
--- a/addons/source-python/plugins/country_tag/country_tag.py
+++ b/addons/source-python/plugins/country_tag/country_tag.py
@@ -19,6 +19,7 @@ from .configs import _configs
 ## GLOBALS
 
 _country_tags = dict()
+_human_players = PlayerIter('human')
 
 ## GAME MANAGEMENT
 
@@ -53,23 +54,19 @@ def _on_player_connect_full(event_data):
         update_tag(player)
 
     if _configs['connection_announce_steamid'].get_int():
-        for human in PlayerIter('human'):
-            SayText2(CONNECT_STEAMID_ANNOUNCE.get_string(
-                    human.language[:2],
-                    name=player.name, 
-                    steamid=player.steamid, 
-                    country=_country_tags[player.userid].name
-                )
-            ).send(human.index)
+        CONNECT_STEAMID_ANNOUNCE.send(
+            _human_players,
+            name=player.name,
+            steamid=player.steamid,
+            country=_country_tags[player.userid].name,
+        )
 
     if _configs['connection_announce'].get_int():
-        for human in PlayerIter('human'):
-            SayText2(CONNECT_ANNOUNCE.get_string(
-                    human.language[:2],
-                    name=player.name, 
-                    country=_country_tags[player.userid].name
-                )
-            ).send(human.index)
+        CONNECT_STEAMID_ANNOUNCE.send(
+            _human_players,
+            name=player.name,
+            country=_country_tags[player.userid].name,
+        )
 
 
 @Event('player_disconnect')

--- a/addons/source-python/plugins/country_tag/strings.py
+++ b/addons/source-python/plugins/country_tag/strings.py
@@ -1,5 +1,6 @@
 ## IMPORTS
 
+from messages import SayText2
 from translations.strings import LangStrings
 
 
@@ -14,6 +15,6 @@ __all__ = (
 
 strings = LangStrings('country_tag')
 
-CONNECT_ANNOUNCE = strings['Connect Announce']
+CONNECT_ANNOUNCE = SayText2(message=strings['Connect Announce'])
 
-CONNECT_STEAMID_ANNOUNCE = strings['Connect Announce Steamid']
+CONNECT_STEAMID_ANNOUNCE = SayText2(message=strings['Connect Announce Steamid'])


### PR DESCRIPTION
Changed messages to use not send a different message to each and every user.

This is untested, so please test before pulling.